### PR TITLE
Use millisecond precision in default formatter

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -12,7 +12,7 @@ type defaultFormatter struct{}
 
 // Format outputs a message like "2014-02-28 18:15:57 [example] INFO     something happened"
 func (f defaultFormatter) Format(rec *Record) string {
-	return fmt.Sprintf("%s [%s] %-8s %s", fmt.Sprint(rec.Time)[:19], rec.LoggerName, LevelNames[rec.Level], rec.Message)
+	return fmt.Sprintf("%s [%s] %-8s %s", fmt.Sprint(rec.Time)[:23], rec.LoggerName, LevelNames[rec.Level], rec.Message)
 }
 
 var LevelNames = map[Level]string{

--- a/formatter.go
+++ b/formatter.go
@@ -10,7 +10,7 @@ type Formatter interface {
 
 type defaultFormatter struct{}
 
-// Format outputs a message like "2014-02-28 18:15:57 [example] INFO     something happened"
+// Format outputs a message like "2014-02-28 18:15:57.123 [example] INFO     something happened"
 func (f defaultFormatter) Format(rec *Record) string {
 	return fmt.Sprintf("%s [%s] %-8s %s", fmt.Sprint(rec.Time)[:23], rec.LoggerName, LevelNames[rec.Level], rec.Message)
 }

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -14,7 +14,6 @@ func TestDefaultFormatterHasRightDateFormat(t *testing.T) {
 		Time: ts,
 		Message: "Hello World!",
 	}
-	formatter := DefaultFormatter
-	line := formatter.Format(&rec)
+	line := DefaultFormatter.Format(&rec)
 	assert.Equal(t, "2018-06-11 12:35:18.123 [] INFO     Hello World!", line)
 }

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -1,0 +1,20 @@
+package log
+
+import (
+	"testing"
+	"time"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultFormatterHasRightDateFormat(t *testing.T) {
+	// Mon, 11 Jun 2018 12:35:18.123 UTC
+	ts := time.Unix(1528713318, 123000000)
+	rec := Record{
+		Level:INFO,
+		Time: ts,
+		Message: "Hello World!",
+	}
+	formatter := DefaultFormatter
+	line := formatter.Format(&rec)
+	assert.Equal(t, "2018-06-11 12:35:18.123 [] INFO     Hello World!", line)
+}


### PR DESCRIPTION
It's really useful to log the things showing the milliseconds of the timestamps. Especially in systems near to baremetal performance.