### PR TITLE
Make `Level` type implement `envconfig.Decoder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - Nothing
 
+## [1.3.0] - 2019-03-18
+### Added
+- `Level` now implements the `envconfig.Decoder` interface so it can be used in config types
+
+
 ## [1.2.0] - 2019-02-27
 ### Added
 - `ConfigureDefaultLogger` boilerplate for logger configuration

--- a/log.go
+++ b/log.go
@@ -1,9 +1,24 @@
 // Package log is an alternative to log package in standard library.
 package log
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
 type Level int
+
+// Decode fills this level from the given input string.
+// This makes `Level` implement the `Decoder` interface of `envconfig` library,
+// so it can be used in config types seamlessly.
+func (l *Level) Decode(val string) error {
+	if logLevel, ok := logLevelMap[val]; ok {
+		*l = logLevel
+		return nil
+	} else {
+		return fmt.Errorf("Unknown log level configured: %s", val)
+	}
+}
 
 // Logging levels.
 const (


### PR DESCRIPTION
Please note we only add the ability for `Level` type to be part of a config type field. The `Config` type has not been changed for the sake of library stability.

